### PR TITLE
Add support for the GET /searchService/searchByParam endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ let myResponse = scsbClient.getItemsAvailabilityForBarcodes(this.barcodes)
   return Promise.reject(error)
 })
 ```
+
+### Supported Endpoints
+
+See [the SCSB swagger documentation](https://uat-recap.htcinc.com:9093/swagger-ui.html) for the authoritative documentation of each endpoint's params.
+
+| Method     | Endpoint     |
+| :------------- | :------------- |
+| `getItemsAvailabilityForBarcodes(barcodes = [])`|[`/sharedCollection/itemAvailabilityStatus`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/shared-collection-rest-controller/itemAvailabilityStatus)|
+| `searchByParam(queryParams = {})`|[`/searchService/searchByParam`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/search-records-rest-controller/search)|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/scsb-rest-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A light wrapper around SCSB's RESTful interface",
   "main": "scsb_rest_client.js",
   "dependencies": {

--- a/scsb_rest_client.js
+++ b/scsb_rest_client.js
@@ -2,6 +2,7 @@ var request = require('request')
 
 // myClient = new SCSBRestClient({url: "foo", apiKey: "bar"})
 class SCSBRestClient {
+
   constructor ({url = null, apiKey = null}) {
     this.url = url
     this.apiKey = apiKey
@@ -11,17 +12,36 @@ class SCSBRestClient {
     }
   }
 
+  // queryParams is a simple object.
+  // It's keys and values map to the params in /searchService/searchByParam
+  searchByParam (queryParams = {}) {
+    return new Promise((resolve, reject) => {
+      let options = {
+        url: `${this.url}/searchService/searchByParam`,
+        qs: queryParams,
+        headers: this._headers()
+      }
+
+      request.get(options, (error, response, body) => {
+        if (error) {
+          reject(error)
+        } else if (response && response.statusCode === 200) {
+          resolve(JSON.parse(body))
+        } else {
+          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
+        }
+      })
+    })
+  }
+
+  // barcodes is an Array of barcodes
   getItemsAvailabilityForBarcodes (barcodes = []) {
     return new Promise((resolve, reject) => {
       var bodyToSend = {}
       bodyToSend = {barcodes: barcodes}
       var options = {
         url: this.url + '/sharedCollection/itemAvailabilityStatus',
-        headers: {
-          'Accept': 'application/json',
-          'api_key': this.apiKey,
-          'Content-Type': 'application/json'
-        },
+        headers: this._headers(),
         body: JSON.stringify(bodyToSend)
       }
       request.post(options, (error, response, body) => {
@@ -35,6 +55,15 @@ class SCSBRestClient {
       })
     })
   }
+
+  _headers () {
+    return {
+      'Accept': 'application/json',
+      'api_key': this.apiKey,
+      'Content-Type': 'application/json'
+    }
+  }
+
 }
 
 module.exports = SCSBRestClient

--- a/scsb_rest_client.js
+++ b/scsb_rest_client.js
@@ -16,7 +16,7 @@ class SCSBRestClient {
   // It's keys and values map to the params in /searchService/searchByParam
   searchByParam (queryParams = {}) {
     return new Promise((resolve, reject) => {
-      let options = {
+      const options = {
         url: `${this.url}/searchService/searchByParam`,
         qs: queryParams,
         headers: this._headers()


### PR DESCRIPTION
Hey @nonword and @rhernand3z.

This PR:

* Adds support for the SCSB endpoint (GET /searchService/searchByParam)
* Adds usage documentation to the README (maybe we should start using swagger)
* version bump

You couuuullld test this by pulling this branch and doing the following in a `node` console:

```
var SCSBRestClient = require('full/path/to/scsb_rest_client.js')

client = new SCSBRestClient({url: "https://path.to.api.com:PORT", apiKey: "THEPASSWORD"})

client.searchByParam({fieldValue: 33433000829063, fieldName: 'Barcode'}).then(function(response){
  console.log(response)
})
```