### PR TITLE
Added new function addRequestItem to client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is a light wrapper around SCSB's [RESTful interace](https://uat-recap.htcinc.com:9093/swagger-ui.html).
 
+## Version
+> 1.0.2
+
 ## Install
 
 ### With Github
@@ -12,8 +15,8 @@ This is a light wrapper around SCSB's [RESTful interace](https://uat-recap.htcin
 
 ### With NPM
 
-```
-"@nypl/scsb-rest-client": "VERSION"
+```js
+npm i @nypl/scsb-rest-client --save
 ```
 
 ## Usage
@@ -22,7 +25,7 @@ This is a light wrapper around SCSB's [RESTful interace](https://uat-recap.htcin
 
 const SCSBRestClient = require('@nypl/scsb-rest-client')
 
-let scsbClient = new SCSBRestClient({url: "http://theurl.example.com:theports", apiKey: "anAPIKEY"})
+let scsbClient = new SCSBRestClient({ url: "http://theurl.example.com:theports", apiKey: "anAPIKEY" })
 
 let myResponse = scsbClient.getItemsAvailabilityForBarcodes(this.barcodes)
 .then((response) => {
@@ -42,8 +45,19 @@ See [the SCSB swagger documentation](https://uat-recap.htcinc.com:9093/swagger-u
 | :------------- | :------------- |
 | `getItemsAvailabilityForBarcodes(barcodes = [])`|[`/sharedCollection/itemAvailabilityStatus`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/shared-collection-rest-controller/itemAvailabilityStatus)|
 | `searchByParam(queryParams = {})`|[`/searchService/searchByParam`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/search-records-rest-controller/search)|
+| `addRequestItem(data = {})`|[`/requestItem/requestItem`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/request-item-rest-controller/requestItem)|
 
 ## Git Workflow
 
 When you _file_ a PR - it should include a version bump.  
 When you _accept_ a PR - you should push a tag named "vTHEVERSION" (e.g. "v1.0.1")
+
+## Changelog
+
+### v1.0.2
+#### Added
+- Added new function `addRequestItem` to SCSBClient.
+- Added unit tests via chai-as-promised to test new function `addRequestItem`.
+
+#### Updated
+- Updated ReadMe to reflect new version and added documentation for addRequestItem function.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard test && ./node_modules/.bin/mocha test",
+    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha test",
     "lint": "./node_modules/.bin/standard"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@nypl/scsb-rest-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A light wrapper around SCSB's RESTful interface",
   "main": "scsb_rest_client.js",
   "dependencies": {
     "request": "2.53.0"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "mocha": "2.2.5",
+    "chai": "4.0.2",
+    "chai-as-promised": "7.0.0",
+    "mocha": "3.2.0",
     "standard": "6.0.8"
   },
   "standard": {
@@ -17,7 +18,8 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha test"
+    "test": "./node_modules/.bin/standard test && ./node_modules/.bin/mocha test",
+    "lint": "./node_modules/.bin/standard"
   },
   "repository": {
     "type": "git",

--- a/scsb_rest_client.js
+++ b/scsb_rest_client.js
@@ -56,6 +56,46 @@ class SCSBRestClient {
     })
   }
 
+  addRequestItem (data) {
+    if (!data || !Object.keys(data).length) {
+      return Promise.reject('the data parameter is empty or undefined; could not initialize POST request')
+    }
+
+    return new Promise((resolve, reject) => {
+      const options = {
+        url: `${this.url}/requestItem/requestItem`,
+        headers: this._headers(),
+        body: JSON.stringify(data)
+      }
+
+      request.post(options, (error, response, body) => {
+        if (error) {
+          reject(error)
+        }
+
+        if (response) {
+          if (response.statusCode === 200) {
+            resolve(JSON.parse(body))
+          } else {
+            const errorResponse = {
+              errorMessage: 'An error occurred while sending the POST request to the SCSB API'
+            }
+
+            if (response.statusCode) {
+              errorResponse.statusCode = response.statusCode
+            }
+
+            if (response.body) {
+              errorResponse.debugInfo = response.body
+            }
+
+            reject(errorResponse)
+          }
+        }
+      })
+    })
+  }
+
   _headers () {
     return {
       'Accept': 'application/json',

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -48,7 +48,7 @@ describe('SCSBRestClient', function () {
       return addRequestItemPromise.should.be.rejected.and.should.eventually.include({
         'errorMessage': 'An error occurred while sending the POST request to the SCSB API',
         'statusCode': 404
-      });
+      })
     })
   })
 })

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,13 +1,55 @@
 /* eslint no-new:0*/
-const expect = require('chai').expect
+const chai = require('chai')
+const assert = chai.assert
+const expect = chai.expect
+const chaiAsPromised = require('chai-as-promised')
+chai.should()
+chai.use(chaiAsPromised)
+
 const SCSBRestClient = require('../scsb_rest_client.js')
 
 describe('SCSBRestClient', function () {
-  it('Throws an exception if instaniated without an API Key', function () {
-    expect(function () { new SCSBRestClient({url: 'https://example.com'}) }).to.throw(Error, 'SCSBRestClient must be instaniated with a url and apiKey')
+  describe('Constructor', () => {
+    it('shoould throw an exception if instaniated without an API Key', function () {
+      expect(function () { new SCSBRestClient({url: 'https://example.com'}) }).to.throw(Error, 'SCSBRestClient must be instaniated with a url and apiKey')
+    })
+
+    it('should throw exception if instaniated without a URL', function () {
+      expect(function () { new SCSBRestClient({apiKey: 'keepitlikeasecret'}) }).to.throw(Error, 'SCSBRestClient must be instaniated with a url and apiKey')
+    })
   })
 
-  it('Throws an exception if instaniated without a URL', function () {
-    expect(function () { new SCSBRestClient({apiKey: 'keepitlikeasecret'}) }).to.throw(Error, 'SCSBRestClient must be instaniated with a url and apiKey')
+  describe('addRequestItem function', () => {
+    const scsbClient = new SCSBRestClient({ apiKey: 'keepitlikeasecret', url: 'https://example.com' })
+
+    it('Should reject a promise if the data parameter is NULL', () => {
+      const addRequestItemPromise = scsbClient.addRequestItem(null)
+      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+    })
+
+    it('Should reject a promise if the data parameter is UNDEFINED', () => {
+      const addRequestItemPromise = scsbClient.addRequestItem(undefined)
+      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+    })
+
+    it('Should reject a promise if the data parameter is an EMPTY Object', () => {
+      const addRequestItemPromise = scsbClient.addRequestItem({})
+      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+    })
+
+    it('Should reject a promise due to incorrect API_KEY and API_URL', () => {
+      const dummyObject = {
+        patronBarcode: '234567890987654',
+        itemBarcodes: [ '32101058075084' ],
+        requestType: 'RETRIEVAL',
+        deliveryLocation: 'NH'
+      }
+      const addRequestItemPromise = scsbClient.addRequestItem(dummyObject)
+
+      return addRequestItemPromise.should.be.rejected.and.should.eventually.include({
+        'errorMessage': 'An error occurred while sending the POST request to the SCSB API',
+        'statusCode': 404
+      });
+    })
   })
 })

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -10,7 +10,7 @@ const SCSBRestClient = require('../scsb_rest_client.js')
 
 describe('SCSBRestClient', function () {
   describe('Constructor', () => {
-    it('shoould throw an exception if instaniated without an API Key', function () {
+    it('should throw an exception if instaniated without an API Key', function () {
       expect(function () { new SCSBRestClient({url: 'https://example.com'}) }).to.throw(Error, 'SCSBRestClient must be instaniated with a url and apiKey')
     })
 
@@ -22,22 +22,22 @@ describe('SCSBRestClient', function () {
   describe('addRequestItem function', () => {
     const scsbClient = new SCSBRestClient({ apiKey: 'keepitlikeasecret', url: 'https://example.com' })
 
-    it('Should reject a promise if the data parameter is NULL', () => {
+    it('should reject a promise if the data parameter is NULL', () => {
       const addRequestItemPromise = scsbClient.addRequestItem(null)
       return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
     })
 
-    it('Should reject a promise if the data parameter is UNDEFINED', () => {
+    it('should reject a promise if the data parameter is UNDEFINED', () => {
       const addRequestItemPromise = scsbClient.addRequestItem(undefined)
       return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
     })
 
-    it('Should reject a promise if the data parameter is an EMPTY Object', () => {
+    it('should reject a promise if the data parameter is an EMPTY Object', () => {
       const addRequestItemPromise = scsbClient.addRequestItem({})
       return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
     })
 
-    it('Should reject a promise due to incorrect API_KEY and API_URL', () => {
+    it('should reject a promise due to incorrect API_KEY and API_URL', () => {
       const dummyObject = {
         patronBarcode: '234567890987654',
         itemBarcodes: [ '32101058075084' ],

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,6 +1,5 @@
 /* eslint no-new:0*/
 const chai = require('chai')
-const assert = chai.assert
 const expect = chai.expect
 const chaiAsPromised = require('chai-as-promised')
 chai.should()
@@ -24,17 +23,17 @@ describe('SCSBRestClient', function () {
 
     it('should reject a promise if the data parameter is NULL', () => {
       const addRequestItemPromise = scsbClient.addRequestItem(null)
-      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+      return addRequestItemPromise.should.be.rejectedWith('the data parameter is empty or undefined; could not initialize POST request')
     })
 
     it('should reject a promise if the data parameter is UNDEFINED', () => {
       const addRequestItemPromise = scsbClient.addRequestItem(undefined)
-      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+      return addRequestItemPromise.should.be.rejectedWith('the data parameter is empty or undefined; could not initialize POST request')
     })
 
     it('should reject a promise if the data parameter is an EMPTY Object', () => {
       const addRequestItemPromise = scsbClient.addRequestItem({})
-      return assert.isRejected(addRequestItemPromise, 'the data parameter is empty or undefined; could not initialize POST request')
+      return addRequestItemPromise.should.be.rejectedWith('the data parameter is empty or undefined; could not initialize POST request')
     })
 
     it('should reject a promise due to incorrect API_KEY and API_URL', () => {


### PR DESCRIPTION
This PR adds the ability to POST a requestItem to the SCSB API via the addRequestItem function.
All code was linted and unit tests were added to test new functionality.
This method will be used heavily by the HoldRequestConsumer Lambda to process HoldRequests.