### PR TITLE
Implement .search() and log deprecation for searchByParam()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,34 @@ See [the SCSB swagger documentation](https://uat-recap.htcinc.com:9093/swagger-u
 | Method     | Endpoint     |
 | :------------- | :------------- |
 | `getItemsAvailabilityForBarcodes(barcodes = [])`|[`/sharedCollection/itemAvailabilityStatus`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/shared-collection-rest-controller/itemAvailabilityStatus)|
-| `searchByParam(queryParams = {})`|[`/searchService/searchByParam`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/search-records-rest-controller/search)|
-| `addRequestItem(data = {})`|[`/requestItem/requestItem`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/request-item-rest-controller/requestItem)|
+| `addRequestItem(data = {})`                     |[`/requestItem/requestItem`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/request-item-rest-controller/requestItem)|
+| `search(data = {})`                             |[`/searchService/search`](https://uat-recap.htcinc.com:9093/swagger-ui.html#!/search-records-rest-controller/search)|
+| `searchByParam(queryParams = {})`               |`/searchService/searchByParam`(**deprecated**)|
 
 ## Git Workflow
 
-When you _file_ a PR - it should include a version bump.  
-When you _accept_ a PR - you should push a tag named "vTHEVERSION" (e.g. "v1.0.1")
+When you _accept_ a PR - you should:
+
+* Do a version bump in master.
+* push a tag named "vTHEVERSION" (e.g. "v1.0.1")
 
 ## Changelog
 
 ### v1.0.2
+
 #### Added
 - Added new function `addRequestItem` to SCSBClient.
 - Added unit tests via chai-as-promised to test new function `addRequestItem`.
 
 #### Updated
 - Updated ReadMe to reflect new version and added documentation for addRequestItem function.
+
+### v1.0.3
+
+#### Added
+
+- `.search()`
+
+#### Deprecated
+
+- `.searchByParam()`

--- a/scsb_rest_client.js
+++ b/scsb_rest_client.js
@@ -12,9 +12,33 @@ class SCSBRestClient {
     }
   }
 
+  // searchOptions is a simple object.
+  // It's keys and values map to the params in /searchService/search
+  search (searchOptions = {}) {
+    return new Promise((resolve, reject) => {
+      const options = {
+        url: `${this.url}/searchService/search`,
+        body: JSON.stringify(searchOptions),
+        headers: this._headers()
+      }
+
+      request.post(options, (error, response, body) => {
+        if (error) {
+          console.log(error)
+          reject(error)
+        } else if (response && response.statusCode === 200) {
+          resolve(JSON.parse(body))
+        } else {
+          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
+        }
+      })
+    })
+  }
+
   // queryParams is a simple object.
   // It's keys and values map to the params in /searchService/searchByParam
   searchByParam (queryParams = {}) {
+    console.log('searchByParam has been deprecated. Use \'search\'.')
     return new Promise((resolve, reject) => {
       const options = {
         url: `${this.url}/searchService/searchByParam`,


### PR DESCRIPTION
This is the first step toward fixing https://github.com/NYPL-discovery/discovery-api/issues/71.
