### PR TITLE
Update npm request module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.npm-debug.log

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a light wrapper around SCSB's [RESTful interace](https://uat-recap.htcinc.com:9093/swagger-ui.html).
 
 ## Version
-> 1.0.2
+> 1.0.4
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SCSBRestClient
 
-This is a light wrapper around SCSB's [RESTful interace](https://uat-recap.htcinc.com:9093/swagger-ui.html).
+This is a light wrapper around SCSB's [RESTful interace](https://scsb.recaplib.org:9093/swagger-ui.html).
 
 ## Version
 > 1.0.4

--- a/README.md
+++ b/README.md
@@ -75,3 +75,8 @@ When you _accept_ a PR - you should:
 #### Deprecated
 
 - `.searchByParam()`
+
+### v1.0.4
+
+#### Updated
+- Updated NPM packages to address npm request module bug [#1595](https://github.com/request/request/issues/1595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/scsb-rest-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A light wrapper around SCSB's RESTful interface",
   "main": "scsb_rest_client.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@nypl/scsb-rest-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A light wrapper around SCSB's RESTful interface",
   "main": "scsb_rest_client.js",
   "dependencies": {
-    "request": "2.53.0"
+    "request": "2.81.0"
   },
   "devDependencies": {
-    "chai": "4.0.2",
-    "chai-as-promised": "7.0.0",
-    "mocha": "3.2.0",
-    "standard": "6.0.8"
+    "chai": "4.1.1",
+    "chai-as-promised": "7.1.1",
+    "mocha": "3.5.0",
+    "standard": "10.0.3"
   },
   "standard": {
     "env": {

--- a/scsb_rest_client.js
+++ b/scsb_rest_client.js
@@ -1,8 +1,7 @@
-var request = require('request')
+const request = require('request')
 
 // myClient = new SCSBRestClient({url: "foo", apiKey: "bar"})
 class SCSBRestClient {
-
   constructor ({url = null, apiKey = null}) {
     this.url = url
     this.apiKey = apiKey
@@ -29,7 +28,7 @@ class SCSBRestClient {
         } else if (response && response.statusCode === 200) {
           resolve(JSON.parse(body))
         } else {
-          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
+          reject(new Error(`Error hitting SCSB API ${response.statusCode}: ${response.body}`))
         }
       })
     })
@@ -52,7 +51,7 @@ class SCSBRestClient {
         } else if (response && response.statusCode === 200) {
           resolve(JSON.parse(body))
         } else {
-          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
+          reject(new Error(`Error hitting SCSB API ${response.statusCode}: ${response.body}`))
         }
       })
     })
@@ -74,7 +73,7 @@ class SCSBRestClient {
         } else if (response && response.statusCode === 200) {
           resolve(JSON.parse(body))
         } else {
-          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
+          reject(new Error(`Error hitting SCSB API ${response.statusCode}: ${response.body}`))
         }
       })
     })
@@ -82,7 +81,9 @@ class SCSBRestClient {
 
   addRequestItem (data) {
     if (!data || !Object.keys(data).length) {
-      return Promise.reject('the data parameter is empty or undefined; could not initialize POST request')
+      return Promise.reject(
+        new Error('the data parameter is empty or undefined; could not initialize POST request')
+      )
     }
 
     return new Promise((resolve, reject) => {
@@ -127,7 +128,6 @@ class SCSBRestClient {
       'Content-Type': 'application/json'
     }
   }
-
 }
 
 module.exports = SCSBRestClient

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,4 +1,4 @@
-/* eslint no-new:0*/
+/* eslint no-new:0 */
 const chai = require('chai')
 const expect = chai.expect
 const chaiAsPromised = require('chai-as-promised')


### PR DESCRIPTION
This PR updates all NPM modules to newer stable releases. Mainly to fix a bug from the current request module version this module was using that threw a weird POST invalid URI error that has been fixed on a newer version.

By running npm run test, the latest Standard JS spec expected `new Error()` when rejecting a promise. See: https://eslint.org/docs/rules/prefer-promise-reject-errors

Tested and linted all code. 👍 